### PR TITLE
Added Microphone Privacy description to Info.plist (to support Mojave)

### DIFF
--- a/CAPlayThroughSwift/Info.plist
+++ b/CAPlayThroughSwift/Info.plist
@@ -30,5 +30,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone permission is used to capture Input Device and/or System Audio streams.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This app didn't work on Mojave because it needed a Microphone description declaration.